### PR TITLE
Deal with redirected images

### DIFF
--- a/retinaimages.php
+++ b/retinaimages.php
@@ -12,7 +12,7 @@
     define('DISABLE_RI_HEADER',  false);
 
     $document_root   = $_SERVER['DOCUMENT_ROOT'];
-    $requested_uri   = parse_url(urldecode($_SERVER['REQUEST_URI']), PHP_URL_PATH);
+    $requested_uri   = parse_url(urldecode(!empty($_SERVER['REDIRECT_URL']) ? $_SERVER['REDIRECT_URL'] : $_SERVER['REQUEST_URI']), PHP_URL_PATH);
     $requested_file  = basename($requested_uri);
     $source_file     = $document_root.$requested_uri;
     $source_dirname  = pathinfo($source_file, PATHINFO_DIRNAME);


### PR DESCRIPTION
In some cases, $_SERVER['REQUEST_URI'] returns unexpected file url if it's been rewritten.

Assuming there is such a rewrite rule comes before the Retina-images':

```
RewriteRule A.JPG$ B.JPG [L]

RewriteCond %{HTTP:Cookie} devicePixelRatio [NC]
RewriteRule \.(?:jpe?g|gif|png|bmp)$ /retinaimages.php [NC,L]    
```

In this case retinaimages.php treats the image still as A.JPG rather B.JPG which is incorrect.

I haven't fully tested the pull request, it just means something to be added there.
